### PR TITLE
Standardize handling of builtin imports between Python versions

### DIFF
--- a/classify_imports.py
+++ b/classify_imports.py
@@ -7,6 +7,7 @@ import operator
 import os.path
 import stat
 import sys
+from importlib.util import find_spec
 from typing import Any
 from typing import Callable
 from typing import Generator
@@ -78,115 +79,62 @@ def _find_local(path: tuple[str, ...], base: str) -> bool:
         return False
 
 
-if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
-    @functools.lru_cache(maxsize=None)
-    def _get_app(app_dirs: tuple[str, ...]) -> tuple[str, ...]:
-        app_dirs_ret = []
-        filtered_stats = set()
-        for p in app_dirs:
-            try:
-                p, key = _path_key(p)
-            except OSError:
-                continue
-            else:
-                if key not in filtered_stats:
-                    app_dirs_ret.append(p)
-                    filtered_stats.add(key)
-
-        return tuple(app_dirs_ret)
-
-    @functools.lru_cache(maxsize=None)
-    def classify_base(base: str, settings: Settings = Settings()) -> str:
+@functools.lru_cache(maxsize=None)
+def _get_app(app_dirs: tuple[str, ...]) -> tuple[str, ...]:
+    app_dirs_ret = []
+    filtered_stats = set()
+    for p in app_dirs:
         try:
-            return _STATIC_CLASSIFICATIONS[base]
-        except KeyError:
-            pass
-
-        if base in sys.stdlib_module_names:
-            return Classified.BUILTIN
-        elif (
-                base in settings.unclassifiable_application_modules or
-                _find_local(_get_app(settings.application_directories), base)
-        ):
-            return Classified.APPLICATION
+            p, key = _path_key(p)
+        except OSError:
+            continue
         else:
-            return Classified.THIRD_PARTY
+            if key not in filtered_stats:
+                app_dirs_ret.append(p)
+                filtered_stats.add(key)
 
+    return tuple(app_dirs_ret)
+
+
+_STDLIB_PATH = None
+try:  # pragma: <3.12 cover
+    from distutils.sysconfig import get_python_lib
+    _STDLIB_PATH = get_python_lib(standard_lib=True)
+except ImportError:  # pragma: >=3.12 cover
+    # distutils to be removed in CPython 3.12 https://peps.python.org/pep-0632/
+    from sysconfig import get_config_var
+    _STDLIB_PATH = get_config_var('DESTLIB')
+
+
+if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
+    _BUILTIN_MODS = frozenset(sys.stdlib_module_names)
 else:  # pragma: <3.10 cover
-    import importlib.machinery
-
     _BUILTIN_MODS = frozenset(sys.builtin_module_names)
 
-    @functools.lru_cache(maxsize=None)
-    def _get_path(
-            sys_path: tuple[str, ...],
-            app_dirs: tuple[str, ...],
-            pythonpath: str | None,
-    ) -> tuple[Callable[[str], object | None], tuple[str, ...]]:
-        app_dirs_ret = []
-        filtered_stats = set()
-        for p in app_dirs:
-            try:
-                p, key = _path_key(p)
-            except OSError:
-                continue
-            else:
-                if key not in filtered_stats:
-                    app_dirs_ret.append(p)
-                    filtered_stats.add(key)
 
-        if pythonpath:  # subtract out pythonpath from sys.path
-            for p in pythonpath.split(os.pathsep):
-                try:
-                    filtered_stats.add(_path_key(p)[1])
-                except OSError:
-                    pass
+@functools.lru_cache(maxsize=None)
+def classify_base(base: str, settings: Settings = Settings()) -> str:
+    try:
+        return _STATIC_CLASSIFICATIONS[base]
+    except KeyError:
+        pass
 
-        sys_path_ret = []
-        for p in sys_path:
-            # subtract out site-packages
-            if p.rstrip('/\\').endswith('-packages'):
-                continue
+    if base in settings.unclassifiable_application_modules:
+        return Classified.APPLICATION
+    elif base in _BUILTIN_MODS:
+        return Classified.BUILTIN
 
-            try:
-                p, key = _path_key(p)
-            except OSError:
-                continue
-            else:
-                if key not in filtered_stats:
-                    sys_path_ret.append(p)
-                    filtered_stats.add(key)
+    app = _get_app(settings.application_directories)
 
-        finder = functools.partial(
-            importlib.machinery.PathFinder.find_spec,
-            path=sys_path_ret,
-        )
-        return finder, tuple(app_dirs_ret)
-
-    @functools.lru_cache(maxsize=None)
-    def classify_base(base: str, settings: Settings = Settings()) -> str:
-        try:
-            return _STATIC_CLASSIFICATIONS[base]
-        except KeyError:
-            pass
-
-        if base in settings.unclassifiable_application_modules:
-            return Classified.APPLICATION
-        elif base in _BUILTIN_MODS:
+    if _find_local(app, base):
+        return Classified.APPLICATION
+    elif find_spec(base) is not None:  # pragma: <3.10 cover
+        spec = find_spec(base)
+        if spec and _STDLIB_PATH and spec.origin and \
+                spec.origin.startswith(_STDLIB_PATH) \
+                and not spec.origin.rstrip('/\\').endswith('-packages'):
             return Classified.BUILTIN
-
-        find_stdlib, app = _get_path(
-            tuple(sys.path),
-            settings.application_directories,
-            os.environ.get('PYTHONPATH'),
-        )
-
-        if _find_local(app, base):
-            return Classified.APPLICATION
-        elif find_stdlib(base) is not None:
-            return Classified.BUILTIN
-        else:
-            return Classified.THIRD_PARTY
+    return Classified.THIRD_PARTY
 
 
 def _ast_alias_to_s(node: ast.alias) -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,pypy3,pre-commit
+envlist = py37,py38,py39,py310,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
In Python 3.10+, we have access to [`sys.stdlib_module_names`](https://docs.python.org/3.10/library/sys.html#sys.stdlib_module_names), which lets us know all of the modules that are considered part of the Python stdlib — regardless of whether they are compiled into the current Python interpreter.

In earlier versions of Python 3, we have only [`sys.builtin_module_names`](https://docs.python.org/3.10/library/sys.html#sys.builtin_module_names), which tells us the modules that are compiled into the current interpreter.

To work around this, we need a solution to tell us whether a module that is not compiled into the current interpreter should be considered part of the stdlib. The previous approach considered all paths inside `sys.path`, excluding those ending with `-packages` (to exclude `site-packages` and `dist-packages`), to contain only stdlib modules. We also excluded the paths found in the `PYTHONPATH` environment variable, reasoning that if a path was present in `sys.path` because it was added by `PYTHONPATH`, it was a path falling outside the default Python interpreter paths. If we found the module in question within one of these paths, we'd report it as a builtin.

With this change, we instead use [`distutils.sysconfig.get_python_lib(standard_lib=True)`](https://docs.python.org/3.10/distutils/apiref.html?highlight=sysconfig%20get_python_lib#distutils.sysconfig.get_python_lib), which directly reports the path used for the standard library (and not third-party extensions).

Finally, we're making the order of resolution consistent among Python versions. We check, in priority order:
1. If the module is specified in `unclassifiable_application_modules` (this is our "manual override")
1. If the module is in the list of known builtins
1. If the module can be found in the application path, influenced by the `application_directories` setting
1. If the module can be found in the standard library path If none of the above match, we assume the import is a third-party module.

Under Python 3.10+, we expect that check 4 never matches without check 2 having matched first.

All of this also allows us to reduce much of the code duplication introduced in bdc924875711a6f7a9239cec92f9cafe4c3ba657.

Tests are updated to reflect these new cases, and `tox.ini` adds all the interpreter versions we care about. We're also able to remove a previous version-specific test skip that was necessary due to the version-inconsistent behavior, but no longer performs differently among versions.

Fixes #155.